### PR TITLE
docs: update README and technical documentation

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,216 @@
+![logo](./docs/logo.png)
+
+# Alt-Tab
+
+> [!WARNING]
+>
+> 이 프로젝트는 현재 개발 중입니다.
+
+[![License: MIT][license-image]][license-url]
+
+한국어 | [English](./README.md)
+
+## 개요
+
+Alt-Tab은 클라우드 동기화와 안전한 공유 기능을 제공하는 지능형 탭 관리 브라우저 확장 프로그램 및 웹 애플리케이션입니다. 비활성 상태의 탭을 자동으로 감지하고 저장하여 작업 공간을 깔끔하게 유지하면서 여러 디바이스에서 쉽게 복원할 수 있습니다.
+
+**저장소**
+- Frontend: [SimYunSup/alt-tab-extension](https://github.com/SimYunSup/alt-tab-extension)
+- Backend: [knight7024/alt-tab](https://github.com/knight7024/alt-tab)
+
+## 모노레포 구조
+
+pnpm 모노레포로 구성되어 있습니다:
+
+- **`packages/extension`** - 브라우저 확장 프로그램 (Chrome, Firefox)
+- **`packages/web`** - QR 코드 탭 공유 및 복원을 위한 웹 앱
+
+## 기능
+
+### 브라우저 확장 프로그램
+
+- **자동 탭 관리**
+  - 설정한 시간(1-240분) 동안 비활성 상태인 탭을 감지하고 저장
+  - 다양한 비활성 감지 모드:
+    | 모드 | 설명 | 지원 |
+    |------|------|------|
+    | window | 윈도우/탭 전환 시 비활성 | 모든 브라우저 |
+    | visibility | 탭이 숨겨질 때 비활성 | 모든 브라우저 |
+    | idle | 사용자 상호작용이 없을 때 | Chrome/Edge만 |
+  - 탭 보호 옵션: 언로드된 탭, 오디오 재생 중인 탭, 고정된 탭, 컨테이너/그룹 탭 무시
+- **URL별 커스텀 규칙**
+  - URL 패턴을 사용하여 특정 웹사이트에 개별 설정 적용
+- **클라우드 동기화**
+  - Google OAuth를 통해 여러 디바이스에서 설정과 탭 동기화
+- **탭 그룹 아카이빙**
+  - 종단간 암호화(PIN 기반, Argon2id + AES-256-GCM)로 탭 그룹 보관
+  - QR 코드를 통한 디바이스 간 공유 및 복원
+
+### 웹 애플리케이션
+
+- **QR 코드 탭 복원**
+  - QR 코드 스캔으로 공유된 탭 그룹 복원
+  - 보안을 위한 PIN 기반 복호화
+  - 확장 프로그램 설치 감지 및 안내
+  - 확장 프로그램이 없을 경우 직접 탭 열기로 대체
+
+## 개발
+
+### 필수 조건
+
+- Node.js 18+
+- pnpm 10+
+
+### 설치
+
+```bash
+# 모든 패키지의 의존성 설치
+pnpm install
+```
+
+### 개발 명령어
+
+```bash
+# Chrome에서 확장 프로그램 개발 모드 실행
+pnpm dev
+
+# Firefox에서 확장 프로그램 실행
+pnpm dev:firefox
+
+# 웹 앱 실행
+pnpm dev:web
+
+# 모든 패키지 빌드
+pnpm build:all
+
+# 확장 프로그램만 빌드
+pnpm build
+
+# 웹 앱만 빌드
+pnpm build:web
+```
+
+### 패키지별 스크립트
+
+#### Extension (`packages/extension`)
+
+```bash
+cd packages/extension
+
+# 개발
+pnpm dev              # Chrome
+pnpm dev:firefox      # Firefox
+
+# 빌드
+pnpm build            # Chrome용 프로덕션 빌드
+pnpm build:firefox    # Firefox용 프로덕션 빌드
+
+# 패키징
+pnpm zip              # 배포용 .zip 생성
+pnpm zip:firefox      # Firefox용 .zip
+
+# 테스트
+pnpm test             # 테스트 실행
+```
+
+#### Web App (`packages/web`)
+
+```bash
+cd packages/web
+
+# 개발
+pnpm dev              # 개발 서버 시작
+
+# 빌드
+pnpm build            # 프로덕션 빌드
+
+# 미리보기
+pnpm preview          # 프로덕션 빌드 미리보기
+```
+
+## 환경 변수
+
+### Extension
+
+`packages/extension/`에 `.env` 파일 생성:
+
+```env
+# 백엔드 API URL (OAuth 및 API 호출에 필요)
+VITE_OAUTH_BASE_URL=http://localhost:8080
+
+# 프로덕션용:
+# VITE_OAUTH_BASE_URL=https://your-backend-domain.com
+```
+
+### Web App
+
+`packages/web/`에 `.env` 파일 생성:
+
+```env
+# 백엔드 API URL
+VITE_API_BASE_URL=http://localhost:8080
+
+# 프로덕션용:
+# VITE_API_BASE_URL=https://your-backend-domain.com
+```
+
+## 기술 스택
+
+### Extension
+- **프레임워크**: WXT (브라우저 확장 프레임워크)
+- **UI**: React, Tailwind CSS, Radix UI, Lucide React
+- **데이터**: Dexie (IndexedDB), webext-bridge (메시징)
+- **보안**: hash-wasm (Argon2id), Web Crypto API (AES-256-GCM)
+- **언어**: TypeScript
+
+### Web App
+- **프레임워크**: Vite, React
+- **UI**: Tailwind CSS, Radix UI
+
+### 지원 브라우저
+- Chrome / Edge (Manifest V3)
+- Firefox (Manifest V2)
+
+## 아키텍처
+
+### 탭 공유 플로우
+
+1. **Extension**: 사용자가 PIN으로 탭 그룹 보관
+   - PIN에서 파생된 키(Argon2id)로 탭 데이터 암호화
+   - 백엔드 서버로 전송
+2. **Backend**: 암호화된 탭 그룹 저장, 공유 URL 생성
+3. **QR Code**: 확장 프로그램이 공유 URL이 담긴 QR 코드 생성
+4. **Web App**:
+   - 사용자가 QR 코드 스캔 → 공유 URL 열기
+   - 확장 프로그램 설치 여부 감지 (content script bridge 통해)
+   - 사용자가 PIN 입력 → 탭 그룹 복호화
+   - 확장 프로그램 또는 직접 브라우저 API를 통해 탭 복원
+
+### Extension-Web 통신
+
+웹 앱과 확장 프로그램 간 통신:
+- **Content Script Bridge** (`entrypoints/content/bridge.ts`)
+- **window.postMessage** API를 통한 컨텍스트 간 메시징
+- 웹 페이지에서 직접 chrome.runtime 접근 불가
+
+## 기여
+
+기여를 환영합니다! 이슈와 Pull Request를 자유롭게 제출해 주세요.
+
+## 문서
+
+- [기술 문서](./docs/README.md) - 상세 아키텍처 및 API 레퍼런스
+- [E2EE 아키텍처](./docs/E2EE-ARCHITECTURE.md) - 종단간 암호화 설계
+
+## 라이선스
+
+[MIT](LICENSE.md)
+
+## 참고 자료
+
+- [WXT Framework](https://wxt.dev/)
+- [Chrome Extensions API](https://developer.chrome.com/docs/extensions/)
+- [Firefox WebExtensions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions)
+
+[license-image]: https://img.shields.io/badge/License-MIT-brightgreen.svg?style=flat-square
+[license-url]: https://opensource.org/licenses/MIT

--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@
 
 [![License: MIT][license-image]][license-url]
 
+[한국어](./README.ko.md) | English
+
 ## Overview
 
 Alt-Tab is a browser extension and web application for intelligent tab management with cloud sync and secure sharing capabilities. It automatically detects and stores inactive tabs, keeping your workspace clean while allowing easy restoration across devices.
 
-This project is based on [Alt-Tab Server Repository](https://github.com/knight7024/alt-tab) by [knight7024](https://github.com/knight7024).
+**Repositories**
+- Frontend: [SimYunSup/alt-tab-extension](https://github.com/SimYunSup/alt-tab-extension)
+- Backend: [knight7024/alt-tab](https://github.com/knight7024/alt-tab)
 
 ## Monorepo Structure
 
@@ -26,15 +30,21 @@ This is a pnpm monorepo containing:
 ### Browser Extension
 
 - **Automatic Tab Management**
-  - Detects and stores tabs that have been inactive for a defined period
-  - Customizable timeout and inactivity detection modes
+  - Detects and stores tabs that have been inactive for a defined period (1-240 minutes)
+  - Multiple inactivity detection modes:
+    | Mode | Description | Support |
+    |------|-------------|---------|
+    | window | Inactive on window/tab switch | All browsers |
+    | visibility | Inactive when tab is hidden | All browsers |
+    | idle | Inactive when no user interaction | Chrome/Edge only |
+  - Tab protection options: ignore unloaded tabs, audio-playing tabs, pinned tabs, container/group tabs
 - **URL-Specific Rules**
   - Apply custom settings for specific websites using URL patterns
 - **Cloud Sync**
   - Sync settings and tabs across devices via Google OAuth
 - **Tab Archiving**
-  - Archive tab groups with end-to-end encryption (PIN-based)
-  - Share tab groups via QR code
+  - Archive tab groups with end-to-end encryption (PIN-based, Argon2id + AES-256-GCM)
+  - Share tab groups via QR code for cross-device restoration
 
 ### Web Application
 
@@ -144,6 +154,23 @@ VITE_API_BASE_URL=http://localhost:8080
 # VITE_API_BASE_URL=https://your-backend-domain.com
 ```
 
+## Tech Stack
+
+### Extension
+- **Framework**: WXT (Browser extension framework)
+- **UI**: React, Tailwind CSS, Radix UI, Lucide React
+- **Data**: Dexie (IndexedDB), webext-bridge (messaging)
+- **Security**: hash-wasm (Argon2id), Web Crypto API (AES-256-GCM)
+- **Language**: TypeScript
+
+### Web App
+- **Framework**: Vite, React
+- **UI**: Tailwind CSS, Radix UI
+
+### Supported Browsers
+- Chrome / Edge (Manifest V3)
+- Firefox (Manifest V2)
+
 ## Architecture
 
 ### Tab Sharing Flow
@@ -170,9 +197,20 @@ Web app communicates with extension using:
 
 Contributions are welcome! Please feel free to submit issues and pull requests.
 
+## Documentation
+
+- [Technical Documentation (Korean)](./docs/README.md) - Detailed architecture and API reference
+- [E2EE Architecture (Korean)](./docs/E2EE-ARCHITECTURE.md) - End-to-end encryption design
+
 ## License
 
 [MIT](LICENSE.md)
+
+## References
+
+- [WXT Framework](https://wxt.dev/)
+- [Chrome Extensions API](https://developer.chrome.com/docs/extensions/)
+- [Firefox WebExtensions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions)
 
 [license-image]: https://img.shields.io/badge/License-MIT-brightgreen.svg?style=flat-square
 [license-url]: https://opensource.org/licenses/MIT

--- a/docs/E2EE-ARCHITECTURE.md
+++ b/docs/E2EE-ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # E2EE (End-to-End Encryption) 아키텍처 설계
 
+[메인 README (한국어)](../README.ko.md) | [Main README (English)](../README.md)
+
 ## 목차
 1. [개요](#개요)
 2. [보안 요구사항](#보안-요구사항)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 비활성 탭을 자동으로 감지하고 저장하는 브라우저 확장 프로그램
 
+[메인 README (한국어)](../README.ko.md) | [Main README (English)](../README.md)
+
 **저장소**
 - Frontend: [SimYunSup/alt-tab-extension](https://github.com/SimYunSup/alt-tab-extension)
 - Backend: [knight7024/alt-tab](https://github.com/knight7024/alt-tab)
@@ -40,35 +42,37 @@
 ### 디바이스 동기화
 Google OAuth 인증으로 설정을 여러 디바이스에서 동기화
 
-### 탭 그룹 아카이빙 (개발 중)
+### 탭 그룹 아카이빙
 - 여러 탭을 그룹으로 서버에 저장
 - PIN 코드 보호
 - E2EE 종단간 암호화
+- QR 코드를 통한 디바이스 간 공유
 
 ## 기술 스택
 
 ### Frontend
 
 **Core**
-- WXT 0.20.7 - 브라우저 확장 프레임워크
-- React 19.1.0
-- TypeScript 5.8.3
-- Tailwind CSS 4.1.10
+- WXT - 브라우저 확장 프레임워크
+- React
+- TypeScript
+- Tailwind CSS
 
 **UI**
 - Radix UI - 접근성 UI 컴포넌트
 - Lucide React - 아이콘
+- Sonner - 토스트 알림
 
 **Data**
-- Dexie 4.0.11 - IndexedDB wrapper
-- SWR 2.3.3 - 데이터 페칭 & 캐싱
-- webext-bridge 6.0.1 - 메시지 전달
+- Dexie - IndexedDB wrapper
+- Ky - HTTP 클라이언트
+- webext-bridge - 메시지 전달
 
 **Security**
-- @node-rs/argon2 2.0.2 - 패스워드 해싱
-- Web Crypto API - AES-GCM 암호화
+- hash-wasm - Argon2id PIN 기반 키 파생
+- Web Crypto API - AES-256-GCM 암호화
 
-**Supported Browsers**: Chrome, Edge, Firefox
+**Supported Browsers**: Chrome, Edge (Manifest V3), Firefox (Manifest V2)
 
 ### Backend
 
@@ -83,28 +87,47 @@ Google OAuth 인증으로 설정을 여러 디바이스에서 동기화
 ### 디렉토리 구조
 
 ```
-entrypoints/
-├── background/index.ts        # 서비스 워커
-├── content/index.ts           # 탭 모니터링
-└── popup/
-    ├── pages/
-    │   ├── CurrentTabs.tsx    # 현재 탭
-    │   ├── RecordTabs.tsx     # 닫힌 탭 기록
-    │   ├── ArchiveTabs.tsx    # 아카이브된 탭 그룹
-    │   └── Setting.tsx        # 설정
-    └── hooks/
-
-types/
-├── data.d.ts
-├── server.d.ts
-└── client.d.ts
-
-utils/
-├── crypto.ts                  # 암호화
-├── db.ts                      # IndexedDB
-├── Tab.ts                     # 탭 관리
-├── Setting.ts                 # 설정 관리
-└── api.ts                     # API 클라이언트
+packages/
+├── extension/                  # 브라우저 확장 프로그램
+│   ├── entrypoints/
+│   │   ├── background/         # 서비스 워커
+│   │   │   ├── index.ts
+│   │   │   ├── messaging.ts    # 메시지 핸들러
+│   │   │   ├── oauth.ts        # OAuth 인증
+│   │   │   ├── tab-lifecycle.ts
+│   │   │   └── tab-restore.ts
+│   │   ├── content/
+│   │   │   ├── index.ts        # 탭 모니터링
+│   │   │   └── bridge.ts       # 웹앱 통신 브릿지
+│   │   ├── popup/
+│   │   │   ├── pages/
+│   │   │   │   ├── CurrentTabs.tsx
+│   │   │   │   ├── RecordTabs.tsx
+│   │   │   │   ├── ArchiveTabs.tsx
+│   │   │   │   └── Setting.tsx
+│   │   │   └── hooks/
+│   │   └── components/
+│   │       ├── ui/             # Radix UI 컴포넌트
+│   │       └── Login/
+│   ├── utils/
+│   │   ├── storage.ts          # WXT 스토리지
+│   │   ├── db.ts               # IndexedDB (Dexie)
+│   │   ├── Tab.ts              # 탭 관리
+│   │   ├── Setting.ts          # 설정 관리
+│   │   ├── ArchivedTabGroup.ts # 탭 그룹 아카이빙
+│   │   └── api/                # API 클라이언트
+│   │       └── client.ts
+│   └── types/
+│       └── data.d.ts
+├── web/                        # QR 코드 공유용 웹 앱
+│   └── src/
+└── shared/                     # 공유 패키지
+    └── src/
+        ├── crypto/             # 암호화 유틸
+        │   ├── aes.ts          # AES-256-GCM
+        │   ├── pin.ts          # PIN 키 파생
+        │   └── sensitive-data.ts
+        └── logger.ts
 ```
 
 ### 컴포넌트 통신
@@ -112,13 +135,23 @@ utils/
 ```
 Background Service Worker ↔ Content Script ↔ Popup UI
 (webext-bridge를 통한 메시지 전달)
+
+Web App → Content Script Bridge → Background
+(window.postMessage + runtime.sendMessage)
 ```
 
-**메시지 타입**
+**내부 메시지 타입 (webext-bridge)**
 - `refresh-tab`: 탭 활동 새로고침
 - `refresh-interval`: 간격 새로고침
-- `get-tab-info`: 탭 정보 조회
-- `send-tab-group`: 탭 그룹 전송
+- `send-tab-group`: 탭 그룹 암호화 및 전송
+- `restore-storage`: 페이지 상태 복원
+
+**외부 메시지 타입 (Web App → Extension)**
+- `ping`: 확장 프로그램 설치 확인
+- `restore_tabs`: 탭 복원 요청
+- `open_tab`: 새 탭 열기
+- `open_settings`: 설정 페이지 열기
+- `get_redirect_url`: 내부 웹 URL 조회
 
 ### 스토리지
 
@@ -131,11 +164,12 @@ Background Service Worker ↔ Content Script ↔ Popup UI
 "local:settings": Setting
 "local:accessToken": string | null
 "local:refreshToken": string | null
+"local:tabGroupCreatedAt": Record<groupId, number>  // 아카이브 메타데이터
 ```
 
 **IndexedDB (Dexie)**
 ```typescript
-recordTabs: RecordTabInfo[]
+recordTabs: RecordTabInfo[]  // 닫힌 탭 기록
 ```
 
 ### 핵심 플로우
@@ -164,10 +198,11 @@ GET /stash-setting             # 설정 조회
 PUT /stash-setting/update      # 설정 업데이트
 ```
 
-**탭 그룹** (개발 중)
+**탭 그룹**
 ```
-POST /tab-group                # 아카이브 생성
-GET  /tab-group                # 아카이브 조회
+POST /tab-group                # 아카이브 생성 (암호화된 데이터)
+GET  /tab-group                # 아카이브 목록 조회
+GET  /tab-group/:id            # 아카이브 상세 조회
 ```
 
 ## 데이터베이스
@@ -219,17 +254,30 @@ db.recordTabs
 - Access Token & Refresh Token 자동 갱신
 - `chrome.identity.launchWebAuthFlow()` 사용
 
-**암호화 유틸 (utils/crypto.ts)**
-- Argon2id 패스워드 해싱 (16 bytes salt, 32 bytes output)
-- AES-256-GCM 암호화 (12 bytes IV, Non-extractable key)
-- 제공 함수: `generateRandomBytes`, `hashPinWithArgon`, `importAesKey`, `aesGcmEncrypt`, `aesGcmDecrypt`
+**암호화 유틸 (@alt-tab/shared/crypto)**
 
-### 개발 중
+PIN 기반 E2EE (End-to-End Encryption) 구현:
 
-- 탭 그룹 아카이빙 E2EE 통합
-- PIN 검증 (현재 클라이언트만)
-- QR 코드 공유
-- 다중 디바이스 키 동기화
+1. **키 파생** (Argon2id)
+   - 입력: 사용자 PIN + 16바이트 랜덤 솔트
+   - 파라미터: t_cost=3, m_cost=65536, parallelism=1
+   - 출력: 32바이트 AES-256 키
+
+2. **데이터 암호화** (AES-256-GCM)
+   - 12바이트 랜덤 IV
+   - 인증된 암호화 (AEAD)
+
+**제공 모듈:**
+- `@alt-tab/shared/crypto/pin` - PIN 키 파생
+- `@alt-tab/shared/crypto/aes` - AES-GCM 암호화/복호화
+- `@alt-tab/shared/crypto/sensitive-data` - 민감 데이터 처리
+- `@alt-tab/shared/crypto/encoding` - Base64/UTF-8 인코딩
+
+### 탭 그룹 아카이빙
+
+- 탭 그룹 E2EE 암호화 후 서버 저장
+- PIN 기반 클라이언트 사이드 복호화
+- QR 코드를 통한 디바이스 간 공유
 
 상세 내용은 [E2EE-ARCHITECTURE.md](./E2EE-ARCHITECTURE.md) 참고
 
@@ -237,10 +285,19 @@ db.recordTabs
 
 ### 환경 변수
 
-`.env` 파일:
+**Extension** (`packages/extension/.env`):
 ```bash
 VITE_OAUTH_BASE_URL=<백엔드 API URL>
+VITE_WEB_APP_URL=<웹 앱 URL>
+VITE_USE_MOCK_API=false
 VITE_MANIFEST_DEV_KEY=<Chrome 개발 키>  # 개발만
+```
+
+**Web App** (`packages/web/.env`):
+```bash
+VITE_API_BASE_URL=<백엔드 API URL>
+VITE_CHROME_EXTENSION_ID=<Chrome 확장 ID>
+VITE_FIREFOX_EXTENSION_ID=<Firefox 확장 ID>
 ```
 
 ### 권한
@@ -249,12 +306,13 @@ VITE_MANIFEST_DEV_KEY=<Chrome 개발 키>  # 개발만
 {
   "permissions": [
     "tabs", "tabGroups", "storage", "activeTab",
-    "cookies", "nativeMessaging", "identity",
-    "contextualIdentities"  // Firefox
+    "cookies", "nativeMessaging", "identity", "scripting"
   ],
   "host_permissions": ["<all_urls>"]
 }
 ```
+
+> Firefox의 경우 `contextualIdentities` 권한 추가
 
 ### 빌드 & 실행
 


### PR DESCRIPTION
## Summary

- Add Korean README (`README.ko.md`) with full translation
- Update main `README.md` with language switcher, tech stack, and documentation links
- Comprehensive update to `docs/README.md` technical documentation
- Add navigation links to `docs/E2EE-ARCHITECTURE.md`

## Changes

### README.md (English)
- Add language switcher (한국어 | English)
- Add repository links (Frontend/Backend)
- Add idle detection modes table
- Add tab protection options description
- Add tech stack section
- Add documentation and references sections

### README.ko.md (Korean) - NEW
- Full Korean translation of README.md

### docs/README.md
- Remove outdated version numbers from tech stack
- Update directory structure to reflect monorepo (packages/extension, web, shared)
- Update dependencies:
  - Remove: SWR, @node-rs/argon2
  - Add: Ky (HTTP client), hash-wasm (Argon2id), Sonner (toast)
- Update component communication section with internal/external message types
- Update crypto/security section to reflect `@alt-tab/shared/crypto` modules
- Add Web App environment variables
- Update API endpoints (add `/tab-group/:id`)
- Add `tabGroupCreatedAt` to storage section
- Remove "개발 중" (in development) status from tab group archiving

### docs/E2EE-ARCHITECTURE.md
- Add navigation links to main README files

## Test plan
- [ ] Verify all links work correctly
- [ ] Review Korean translation accuracy
- [ ] Confirm directory structure matches actual codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)